### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/src/server/controllers/transactionController.ts
+++ b/src/server/controllers/transactionController.ts
@@ -11,7 +11,10 @@ export const transactionController = {
       const { productId } = req.body;
       const buyerId = req.user.id;
 
-      const product = await Product.findById(productId).populate('seller');
+      if (typeof productId !== 'string' || !productId.match(/^[0-9a-fA-F]{24}$/)) {
+        return res.status(400).json({ error: 'Invalid product ID' });
+      }
+      const product = await Product.findOne({ _id: { $eq: productId } }).populate('seller');
       if (!product) {
         return res.status(404).json({ error: 'Product not found' });
       }


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palaceofgoods-/security/code-scanning/2](https://github.com/erikg713/Palaceofgoods-/security/code-scanning/2)

To fix the problem, we need to ensure that the `productId` is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator to ensure that the user input is interpreted as a literal value. Additionally, we should validate the `productId` to ensure it is a valid identifier.

1. Use the `$eq` operator in the MongoDB query to ensure the `productId` is treated as a literal value.
2. Validate the `productId` to ensure it is a valid identifier before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
