### PR TITLE
Potential fix for code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/src/server/controllers/productController.ts
+++ b/src/server/controllers/productController.ts
@@ -104,9 +104,17 @@ export const productController = {
         imageUrls = [...imageUrls, ...newImages.map(image => image.secure_url)];
       }
 
+      const allowedUpdates = ['title', 'description', 'price', 'category', 'condition'];
+      const updates = Object.keys(req.body).filter(key => allowedUpdates.includes(key));
+      const updateData: any = {};
+      updates.forEach(key => {
+        updateData[key] = req.body[key];
+      });
+      updateData.images = imageUrls;
+
       const updatedProduct = await Product.findByIdAndUpdate(
         id,
-        { ...req.body, images: imageUrls },
+        updateData,
         { new: true }
       ).populate('seller', 'username avatar');
 


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palaceofgoods-/security/code-scanning/5](https://github.com/erikg713/Palaceofgoods-/security/code-scanning/5)

To fix the problem, we need to ensure that the data from `req.body` is properly validated and sanitized before being used in the database query. This can be achieved by explicitly specifying the fields that are allowed to be updated and validating their values. We can use a library like `Joi` for validation or manually validate the fields.

The best way to fix the problem without changing existing functionality is to:
1. Define a schema for the allowed fields in the `req.body`.
2. Validate the `req.body` against this schema.
3. Use the validated data to construct the update query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
