### PR TITLE
Potential fix for code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/src/server/controllers/productController.ts
+++ b/src/server/controllers/productController.ts
@@ -108,13 +108,16 @@ export const productController = {
       const updates = Object.keys(req.body).filter(key => allowedUpdates.includes(key));
       const updateData: any = {};
       updates.forEach(key => {
-        updateData[key] = req.body[key];
+        if (typeof req.body[key] === 'string' || typeof req.body[key] === 'number') {
+          updateData[key] = req.body[key];
+        }
       });
       updateData.images = imageUrls;
 
+      const updateDataWithSet = { $set: updateData };
       const updatedProduct = await Product.findByIdAndUpdate(
         id,
-        updateData,
+        updateDataWithSet,
         { new: true }
       ).populate('seller', 'username avatar');
 


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palaceofgoods-/security/code-scanning/7](https://github.com/erikg713/Palaceofgoods-/security/code-scanning/7)

To fix the problem, we need to ensure that the user-provided data in `req.body` is properly sanitized before being used in the database query. We can achieve this by using MongoDB's `$set` operator to ensure that the data is interpreted as literal values and not as query objects. Additionally, we should validate the data types of the user-provided values to ensure they are of the expected types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
